### PR TITLE
Enable direct navigation to Versioning Guide

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import MainPage from './pages/MainPage';
 import VersioningGuide from './pages/VersioningGuide';
 
 export default function App() {
   return (
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <HashRouter>
       <div className="min-h-screen bg-slate-50 flex flex-col">
         <Navbar />
         <main id="main-content" className="flex-1">
@@ -15,6 +15,6 @@ export default function App() {
           </Routes>
         </main>
       </div>
-    </BrowserRouter>
+    </HashRouter>
   );
 }

--- a/src/TransitiveDependency.test.jsx
+++ b/src/TransitiveDependency.test.jsx
@@ -1,10 +1,15 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import MainPage from './pages/MainPage';
 
 describe('Transitive Dependency Drift', () => {
   it('displays transitive outliers when a deep dependency is updated', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Chain: reader-a -> common-lib -> ext.models
     

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -16,7 +16,7 @@ export default function Navbar() {
   ];
 
   return (
-    <nav className="bg-white border-b border-slate-200 sticky top-0 z-50">
+    <nav className="bg-white border-b border-slate-200 sticky top-0 z-[60]">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-white focus:text-indigo-600 focus:rounded-md focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"

--- a/src/components/WelcomeModal.jsx
+++ b/src/components/WelcomeModal.jsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useId } from 'react';
-import { UploadCloud, Zap, FilePlus } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { UploadCloud, Zap, FilePlus, BookOpen } from 'lucide-react';
 
 export default function WelcomeModal({ onUpload, onNew, onRandom }) {
   const fileInputRef = useRef(null);
@@ -27,7 +28,16 @@ export default function WelcomeModal({ onUpload, onNew, onRandom }) {
       <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg overflow-hidden border border-slate-200">
         <div className="px-8 py-6 text-center">
           <h2 id={titleId} className="text-2xl font-bold text-slate-800 mb-2">Welcome to DepManager</h2>
-          <p className="text-slate-500 mb-8">How would you like to start your session?</p>
+          <p className="text-slate-500 mb-6">How would you like to start your session?</p>
+          <div className="flex justify-center">
+             <Link
+                to="/guide"
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-indigo-600 bg-indigo-50 hover:bg-indigo-100 rounded-lg transition-colors mb-2"
+              >
+                <BookOpen className="w-4 h-4" />
+                View Versioning Guide first
+              </Link>
+          </div>
         </div>
 
         {/* Hidden input moved outside for valid HTML */}

--- a/src/components/WelcomeModal.test.jsx
+++ b/src/components/WelcomeModal.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import WelcomeModal from './WelcomeModal';
 
 describe('WelcomeModal Component', () => {
@@ -10,7 +11,11 @@ describe('WelcomeModal Component', () => {
   };
 
   it('renders correctly', () => {
-    render(<WelcomeModal {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <WelcomeModal {...defaultProps} />
+      </MemoryRouter>
+    );
     expect(screen.getByText('Welcome to DepManager')).toBeInTheDocument();
     expect(screen.getByText('Upload a Session')).toBeInTheDocument();
     expect(screen.getByText('Start Fresh')).toBeInTheDocument();
@@ -18,7 +23,11 @@ describe('WelcomeModal Component', () => {
   });
 
   it('has accessible dialog role and attributes', () => {
-    render(<WelcomeModal {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <WelcomeModal {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // Should have role="dialog"
     const dialog = screen.getByRole('dialog');
@@ -36,7 +45,11 @@ describe('WelcomeModal Component', () => {
   });
 
   it('sets initial focus to the first interactive element', async () => {
-    render(<WelcomeModal {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <WelcomeModal {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // The "Upload a Session" button should be focused
     // We look for the button containing the text "Upload a Session"

--- a/src/pages/DependencyInteraction.test.jsx
+++ b/src/pages/DependencyInteraction.test.jsx
@@ -1,10 +1,15 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import MainPage from './MainPage';
 
 describe('Dependency Interaction', () => {
   it('allows deleting a dependency', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
 
     // Check node exists
     expect(screen.getByTestId('node-data:repo-a')).toBeInTheDocument();
@@ -31,7 +36,11 @@ describe('Dependency Interaction', () => {
   });
 
   it('allows creating a release with custom version and optional fields', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
 
     const node = screen.getByTestId('node-data:repo-b');
     fireEvent.click(node);

--- a/src/pages/MainPage.AddDependency.test.jsx
+++ b/src/pages/MainPage.AddDependency.test.jsx
@@ -1,10 +1,15 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import MainPage from './MainPage';
 
 describe('Add Dependency Modal', () => {
   it('opens modal when Add Dependency button is clicked', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
 
     // Find the "Add Dependency" button. It might be hidden by text on small screens, so look for text or icon.
     // The button has "Add Dependency" text (hidden sm:inline) and "Add" (sm:hidden).
@@ -17,7 +22,11 @@ describe('Add Dependency Modal', () => {
   });
 
   it('closes modal when Cancel is clicked', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
 
     // Open modal
     const addBtn = screen.getByRole('button', { name: /Add Dependency/i });
@@ -32,7 +41,11 @@ describe('Add Dependency Modal', () => {
   });
 
   it('closes modal when Escape key is pressed', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
 
     // Open modal
     const addBtn = screen.getByRole('button', { name: /Add Dependency/i });
@@ -49,7 +62,11 @@ describe('Add Dependency Modal', () => {
   });
 
   it('creates a new dependency when form is submitted', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
 
     // Open modal
     const addBtn = screen.getByRole('button', { name: /Add Dependency/i });

--- a/src/pages/MainPage.test.jsx
+++ b/src/pages/MainPage.test.jsx
@@ -1,17 +1,26 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import MainPage from './MainPage';
 
 describe('MainPage', () => {
   it('renders the header correctly', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     // Use a more specific query to distinguish from the modal title
     expect(screen.getByRole('heading', { level: 1, name: /DepManager/i })).toBeInTheDocument();
     expect(screen.getByText(/Microservice Version Control/i)).toBeInTheDocument();
   });
 
   it('renders initial nodes', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     // Check for a core node by test id
     expect(screen.getByTestId('node-core:ext-models')).toBeInTheDocument();
     // Check for a repo node by test id
@@ -22,7 +31,11 @@ describe('MainPage', () => {
   });
 
   it('updates sidebar when a node is selected', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Initial state: empty sidebar message
     expect(screen.getByText(/Select a microservice or library/i)).toBeInTheDocument();
@@ -40,7 +53,11 @@ describe('MainPage', () => {
   });
 
   it('bumps version when Patch button is clicked', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Select a node
     const node = screen.getByTestId('node-core:ext-models');
@@ -61,7 +78,11 @@ describe('MainPage', () => {
   });
 
   it('bumps minor version when Minor button is clicked', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Select a node
     const node = screen.getByTestId('node-core:ext-models');
@@ -81,7 +102,11 @@ describe('MainPage', () => {
   });
 
   it('bumps major version when Major button is clicked', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Select a node
     const node = screen.getByTestId('node-core:ext-models');
@@ -101,7 +126,11 @@ describe('MainPage', () => {
   });
 
   it('shows upstream dependencies for a selected node', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Select Reader A which depends on common, repo-a, repo-c, repo-d
     const readerA = screen.getByTestId('node-app:reader-a');
@@ -119,7 +148,11 @@ describe('MainPage', () => {
   });
 
   it('shows downstream dependencies for a selected node', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Select common-lib which is used by multiple readers
     const commonLib = screen.getByTestId('node-core:common-lib');
@@ -134,7 +167,11 @@ describe('MainPage', () => {
   });
 
   it('detects dependency drift and shows Rebuild & Bump App button', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // First bump a core library version
     const extModels = screen.getByTestId('node-core:ext-models');
@@ -173,7 +210,11 @@ describe('MainPage', () => {
   });
 
   it('updates app dependencies when Rebuild & Bump Node is clicked', async () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Bump common version
     const commonLib = screen.getByTestId('node-core:common-lib');
@@ -202,7 +243,11 @@ describe('MainPage', () => {
   });
 
   it('highlights related nodes on hover', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Hover over a node
     const commonLib = screen.getByTestId('node-core:common-lib');
@@ -214,7 +259,11 @@ describe('MainPage', () => {
   });
 
   it('highlights related nodes on selection', () => {
-    render(<MainPage />);
+    render(
+      <MemoryRouter>
+        <MainPage />
+      </MemoryRouter>
+    );
     
     // Select a node
     const commonLib = screen.getByTestId('node-core:common-lib');


### PR DESCRIPTION
This PR addresses the issue where users were unable to navigate directly to the Versioning Guide due to 404 errors on GitHub Pages and the WelcomeModal preventing easy access to the dashboard's navigation.

Changes:
- **Routing**: Migrated from `BrowserRouter` to `HashRouter` in `App.jsx`. This ensures that routes like `/guide` (now `/#/guide`) are handled client-side, preventing 404s on page reloads or direct entry on static hosts like GitHub Pages.
- **UI Improvements**:
  - Added a "View Versioning Guide first" link directly in the `WelcomeModal` to provide an immediate path for new users.
  - Increased the `Navbar` z-index to `z-[60]` to ensure global navigation remains interactive even when the `WelcomeModal` (z-50) is active.
- **Testing**: Updated several test files (`MainPage.test.jsx`, `WelcomeModal.test.jsx`, etc.) to wrap components in a `MemoryRouter`, fixing regressions caused by the introduction of `Link` components.

Verification:
- All 67 unit and integration tests passed.
- Frontend verification with Playwright confirmed the new navigation flow and visibility of the guide.

Fixes #52

---
*PR created automatically by Jules for task [17834524411955042839](https://jules.google.com/task/17834524411955042839) started by @avrezzon*